### PR TITLE
Don't raise an exception on selinux systems without bindings

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -825,7 +825,7 @@ class AnsibleModule(object):
             if seenabled is not None:
                 (rc, out, err) = self.run_command(seenabled)
                 if rc == 0:
-                    self.fail_json(msg="Aborting, target uses selinux but python bindings (libselinux-python) aren't installed!")
+                    return True
             return False
         if selinux.is_selinux_enabled() == 1:
             return True


### PR DESCRIPTION
On a system with selinux enabled but on which we can't interact with it
using the normal python bindings (for example, RHEL7 or Centos 7 when
running python3), we don't need to raise an exception when checking
whether the system has selinux enabled: we can just return true and
let the code carry on, running normally if it doesn't need to perform
selinux operations and failing informatively if it does.