### PR TITLE
Make docker container deprovisioning a bit intelligent when choosing what to deprovision

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2481,17 +2481,12 @@ class ContainerManager(DockerBaseClass):
             # may now have the same name but is actually different
             if self.parameters.labels:
                 config = self.client.inspect_container(self.parameters.name)
-                if not config.get('Config'):
-                    self.fail("absent: Error parsing container properties. Config missing.")
-
-                if 'Labels' not in config['Config']:
-                    self.fail("absent: Error config and container labels do not match.")
                 labels = config['Config']['Labels']
                 if not (self.parameters.labels.items() <= labels.items()):
-                    self.fail("absent: Error config and container labels do not match.")
+                    return None
             if container.running:
                 self.diff_tracker.add('running', parameter=False, active=True)
-            self.container_stop(container.Id)
+                self.container_stop(container.Id)
             self.diff_tracker.add('exists', parameter=False, active=True)
             self.container_remove(container.Id)
 


### PR DESCRIPTION
When deprovisioning docker containers; we should use labels to restrict its search to containers that belong to the current cluster.

Reference: RM19950
Signed-off-by: Haroon <muhammad.haroon@2ndquadrant.com>

##### SUMMARY
Ansible's docker_container module at this point does not really care for anything more than a container name when dealing with 'absent' scenario. So added a little more to the logic when evaluating what to deprovision. It should now consider 'Labels' to extract `Cluster` name and to make sure that the container being deprovisioned actually belongs to the cluster in question. Fixes RM19950.

##### COMPONENT NAME
docker

